### PR TITLE
implements format_file_location

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -603,8 +603,27 @@ impl Builder {
     }
 
     /// Whether or not to write the module path in the default format.
+    /// 
+    /// Cannot be used in combination with [format_file_location](Self::format_file_location).
     pub fn format_module_path(&mut self, write: bool) -> &mut Self {
-        self.format.format_module_path = write;
+        if write && self.format.format_file_location {
+            println!("Cannot use both `format_module_path` and `format_log_location`!")
+        } else {
+            self.format.format_module_path = write;
+        }
+        self
+    }
+
+    /// Whether or not to write the location of the log (file and line number)
+    /// in the default format.
+    /// 
+    /// Cannot be used in combination with [format_module_path](Self::format_file_location).
+    pub fn format_file_location(&mut self, write: bool) -> &mut Self {
+        if write && self.format.format_module_path {
+            println!("Cannot use both `format_module_path` and `format_log_location`!")
+        } else {
+            self.format.format_file_location = write;
+        }
         self
     }
 


### PR DESCRIPTION
Implements a new option to the format builder to make the header on logs display the file and line number a log originated from.

I work on a project (a binary) that uses this library and we often have trouble identifying where scattered warnings / debug messages are actually being fired from. The specificity of files + line numbers is more helpful for us, who will never have these logs displayed to an end-user. 

I tried to implement this with as small of a footprint as possible, but that does lead to a bit of weirdness with the relationship between the new `format_file_location` and `format_module_path`, since they both want control over the header. I have just made it so that attempting to enable both will print out a warning that you can't and then rejects the second request. A more elegant way of handling this may be creating a type that can contain both behaviors (leading to something like `format_header_style(HeaderStyle::ModulePath)`, but I don't love the idea of users having to import a new type. 