### PR TITLE
chore: Update docs and examples to 2018 edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ $ cargo add log env_logger
 `env_logger` must be initialized as early as possible in the project. After it's initialized, you can use the `log` macros to do actual logging.
 
 ```rust
-#[macro_use]
-extern crate log;
+use log::info;
 
 fn main() {
     env_logger::init();
@@ -88,9 +87,6 @@ env_logger = "0.9.0"
 ```
 
 ```rust
-#[macro_use]
-extern crate log;
-
 fn add_one(num: i32) -> i32 {
     info!("add_one called with {}", num);
     num + 1
@@ -99,6 +95,7 @@ fn add_one(num: i32) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use log::info;
 
     fn init() {
         let _ = env_logger::builder().is_test(true).try_init();

--- a/examples/custom_default_format.rs
+++ b/examples/custom_default_format.rs
@@ -17,8 +17,7 @@ $ export MY_LOG_STYLE=never
 If you want to control the logging output completely, see the `custom_logger` example.
 */
 
-#[macro_use]
-extern crate log;
+use log::info;
 
 use env_logger::{Builder, Env};
 

--- a/examples/custom_logger.rs
+++ b/examples/custom_logger.rs
@@ -10,12 +10,9 @@ $ export MY_LOG_LEVEL='info'
 If you only want to change the way logs are formatted, look at the `custom_format` example.
 */
 
-#[macro_use]
-extern crate log;
-
 use env_logger::filter::{Builder, Filter};
 
-use log::{Log, Metadata, Record, SetLoggerError};
+use log::{info, Log, Metadata, Record, SetLoggerError};
 
 const FILTER_ENV: &str = "MY_LOG_LEVEL";
 

--- a/examples/default.rs
+++ b/examples/default.rs
@@ -15,8 +15,7 @@ $ export MY_LOG_STYLE=never
 ```
 */
 
-#[macro_use]
-extern crate log;
+use log::{debug, error, info, trace, warn};
 
 use env_logger::Env;
 

--- a/examples/filters_from_code.rs
+++ b/examples/filters_from_code.rs
@@ -2,12 +2,9 @@
 Specify logging filters in code instead of using an environment variable.
 */
 
-#[macro_use]
-extern crate log;
-
 use env_logger::Builder;
 
-use log::LevelFilter;
+use log::{debug, error, info, trace, warn, LevelFilter};
 
 fn main() {
     Builder::new().filter_level(LevelFilter::max()).init();

--- a/examples/in_tests.rs
+++ b/examples/in_tests.rs
@@ -11,13 +11,12 @@ cargo test --example in_tests
 You should see the `it_does_not_work` test fail and include its log output.
 */
 
-#[cfg_attr(test, macro_use)]
-extern crate log;
-
 fn main() {}
 
 #[cfg(test)]
 mod tests {
+    use log::debug;
+
     fn init_logger() {
         let _ = env_logger::builder()
             // Include all events in tests

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,9 +184,10 @@
 //! The [`Builder::is_test`] method can be used in unit tests to ensure logs will be captured:
 //!
 //! ```
-//! # #[macro_use] extern crate log;
 //! #[cfg(test)]
 //! mod tests {
+//!     use log::info;
+//!
 //!     fn init() {
 //!         let _ = env_logger::builder().is_test(true).try_init();
 //!     }
@@ -359,10 +360,9 @@ pub struct Logger {
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate log;
 /// # use std::io::Write;
 /// use env_logger::Builder;
-/// use log::LevelFilter;
+/// use log::{LevelFilter, error, info};
 ///
 /// let mut builder = Builder::from_default_env();
 ///


### PR DESCRIPTION
We don't need `macro_use` now and I think `use` is more readable.