### PR TITLE
fix: `Target::Pipe` respects `WriteStyle`

### DIFF
--- a/src/fmt/writer/mod.rs
+++ b/src/fmt/writer/mod.rs
@@ -199,7 +199,7 @@ impl Builder {
 
         Writer {
             inner: writer,
-            write_style: self.write_style,
+            write_style: color_choice,
         }
     }
 }

--- a/src/fmt/writer/mod.rs
+++ b/src/fmt/writer/mod.rs
@@ -60,7 +60,7 @@ impl From<Target> for WritableTarget {
         match target {
             Target::Stdout => Self::Stdout,
             Target::Stderr => Self::Stderr,
-            Target::Pipe(pipe) => Self::Pipe(Box::new(Mutex::new(pipe))),
+            Target::Pipe(pipe) => Self::Pipe(Box::new(Mutex::new(pipe) as Mutex<_>)),
         }
     }
 }

--- a/src/fmt/writer/termcolor/extern_impl.rs
+++ b/src/fmt/writer/termcolor/extern_impl.rs
@@ -76,7 +76,7 @@ pub(in crate::fmt::writer) struct BufferWriter {
 
 pub(in crate::fmt) struct Buffer {
     inner: termcolor::Buffer,
-    has_alt_target: bool,
+    has_test_target: bool,
 }
 
 impl BufferWriter {
@@ -108,7 +108,7 @@ impl BufferWriter {
     pub(in crate::fmt::writer) fn buffer(&self) -> Buffer {
         Buffer {
             inner: self.inner.buffer(),
-            has_alt_target: matches!(
+            has_test_target: matches!(
                 self.alt_target,
                 Some(WritableTarget::Stderr | WritableTarget::Stdout)
             ),
@@ -154,7 +154,7 @@ impl Buffer {
 
     fn set_color(&mut self, spec: &ColorSpec) -> io::Result<()> {
         // Ignore styles for test captured logs because they can't be printed
-        if !self.has_alt_target {
+        if !self.has_test_target {
             self.inner.set_color(spec)
         } else {
             Ok(())
@@ -163,7 +163,7 @@ impl Buffer {
 
     fn reset(&mut self) -> io::Result<()> {
         // Ignore styles for test captured logs because they can't be printed
-        if !self.has_alt_target {
+        if !self.has_test_target {
             self.inner.reset()
         } else {
             Ok(())


### PR DESCRIPTION
Resolves https://github.com/rust-cli/env_logger/issues/274.

The old behavior made it impossible to retain colors in custom sinks.

With this patch, the default behavior assumes non-color compliance with the sink. But this can be overridden with `WriteStyle::Always`.