### PR TITLE
Use `std::io::IsTerminal` rather than `is-terminal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+MSRV changed to 1.70 for `std::io::IsTerminal`.
+
+### Improvements
+
+- Switch from `is-terminal` to `std::io::IsTerminal`, removing several dependencies.
+
 ## [0.10.0] - 2022-11-24
 
 MSRV changed to 1.60 to hide optional dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,18 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "cc"
-version = "1.0.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,40 +22,9 @@ name = "env_logger"
 version = "0.10.0"
 dependencies = [
  "humantime",
- "is-terminal",
  "log",
  "regex",
  "termcolor",
-]
-
-[[package]]
-name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -75,40 +32,6 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d367024b3f3414d8e01f437f704f41a9f64ab36f9067fa73e526ad4c763c87"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae5bc6e2eb41c9def29a3e0f1306382807764b9b53112030eff57435667352d"
-dependencies = [
- "hermit-abi",
- "io-lifetimes",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
-name = "libc"
-version = "0.2.137"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
 
 [[package]]
 name = "log"
@@ -141,20 +64,6 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
-name = "rustix"
-version = "0.36.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1fbb4dfc4eb1d390c02df47760bb19a84bb80b301ecc947ab5406394d8223e"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
 
 [[package]]
 name = "termcolor"
@@ -195,60 +104,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["development-tools::debugging"]
 keywords = ["logging", "log", "logger"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.60.0"  # MSRV
+rust-version = "1.70.0"  # MSRV
 include = [
   "build.rs",
   "src/**/*",
@@ -38,7 +38,7 @@ pre-release-replacements = [
 [features]
 default = ["auto-color", "humantime", "regex"]
 color = ["dep:termcolor"]
-auto-color = ["dep:is-terminal", "color"]
+auto-color = ["color"]
 humantime = ["dep:humantime"]
 regex = ["dep:regex"]
 
@@ -47,7 +47,6 @@ log = { version = "0.4.8", features = ["std"] }
 regex = { version = "1.0.3", optional = true, default-features=false, features=["std", "perf"] }
 termcolor = { version = "1.1.1", optional = true }
 humantime = { version = "2.0.0", optional = true }
-is-terminal = { version = "0.4.0", optional = true }
 
 [[test]]
 name = "regexp_filter"

--- a/src/fmt/writer/atty.rs
+++ b/src/fmt/writer/atty.rs
@@ -6,28 +6,12 @@ Otherwise, assume we're not attached to anything. This effectively prevents styl
 printed.
 */
 
-#[cfg(feature = "auto-color")]
-mod imp {
-    use std::io::IsTerminal;
+use std::io::IsTerminal;
 
-    pub(in crate::fmt) fn is_stdout() -> bool {
-        std::io::stdout().is_terminal()
-    }
-
-    pub(in crate::fmt) fn is_stderr() -> bool {
-        std::io::stderr().is_terminal()
-    }
+pub(in crate::fmt) fn is_stdout() -> bool {
+    cfg!(feature = "auto-color") && std::io::stdout().is_terminal()
 }
 
-#[cfg(not(feature = "auto-color"))]
-mod imp {
-    pub(in crate::fmt) fn is_stdout() -> bool {
-        false
-    }
-
-    pub(in crate::fmt) fn is_stderr() -> bool {
-        false
-    }
+pub(in crate::fmt) fn is_stderr() -> bool {
+    cfg!(feature = "auto-color") && std::io::stderr().is_terminal()
 }
-
-pub(in crate::fmt) use self::imp::*;

--- a/src/fmt/writer/atty.rs
+++ b/src/fmt/writer/atty.rs
@@ -8,7 +8,7 @@ printed.
 
 #[cfg(feature = "auto-color")]
 mod imp {
-    use is_terminal::IsTerminal;
+    use std::io::IsTerminal;
 
     pub(in crate::fmt) fn is_stdout() -> bool {
         std::io::stdout().is_terminal()


### PR DESCRIPTION
This removes many large dependencies.
