### PR TITLE
fix(fmt): Fix passing of WriteStyle when using Target::Pipe

### DIFF
--- a/src/fmt/writer/buffer.rs
+++ b/src/fmt/writer/buffer.rs
@@ -31,10 +31,13 @@ impl BufferWriter {
         }
     }
 
-    pub(in crate::fmt::writer) fn pipe(pipe: Box<Mutex<dyn io::Write + Send + 'static>>) -> Self {
+    pub(in crate::fmt::writer) fn pipe(
+        pipe: Box<Mutex<dyn io::Write + Send + 'static>>,
+        write_style: WriteStyle,
+    ) -> Self {
         BufferWriter {
             target: WritableTarget::Pipe(pipe),
-            write_style: WriteStyle::Never,
+            write_style,
         }
     }
 

--- a/src/fmt/writer/mod.rs
+++ b/src/fmt/writer/mod.rs
@@ -138,7 +138,7 @@ impl Builder {
         let writer = match mem::take(&mut self.target) {
             Target::Stdout => BufferWriter::stdout(self.is_test, color_choice),
             Target::Stderr => BufferWriter::stderr(self.is_test, color_choice),
-            Target::Pipe(pipe) => BufferWriter::pipe(Box::new(Mutex::new(pipe))),
+            Target::Pipe(pipe) => BufferWriter::pipe(Box::new(Mutex::new(pipe)), color_choice),
         };
 
         Writer { inner: writer }


### PR DESCRIPTION
Seems like this was overlooked in #298.

Test program:
```Rust
fn main() {
    env_logger::builder()
        .target(env_logger::Target::Pipe(Box::new(std::io::stdout())))
        .write_style(env_logger::WriteStyle::Always)
        .init();
    log::error!("ASD");
}
```

Fixes #274.