### PR TITLE
Workaround cargo bug with enable features of optional dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ pre-release-replacements = [
 
 [features]
 default = ["auto-color", "humantime", "regex"]
-color = ["dep:anstream", "dep:anstyle"]
+color = ["anstream", "anstyle"]
 auto-color = ["color", "anstream/auto"]
 humantime = ["dep:humantime"]
 regex = ["env_filter/regex"]


### PR DESCRIPTION
While this works fine with Rust 1.73+, it does not work with Rust 1.70 and fails like this:

```
error: Package `env_logger v0.11.1` does not have feature `anstream`. It has an optional dependency with that name, but that dependency uses the "dep:" syntax in the features table, so it does not have an implicit feature with that name.
```