### PR TITLE
Fix introduced dependency on anstream by auto-color

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ pre-release-replacements = [
 [features]
 default = ["auto-color", "humantime", "regex"]
 color = ["dep:anstream", "dep:anstyle"]
-auto-color = ["color", "anstream/auto"]
+auto-color = ["color", "anstream?/auto"]
 humantime = ["dep:humantime"]
 regex = ["env_filter/regex"]
 unstable-kv = ["log/kv"]


### PR DESCRIPTION
Fixes https://github.com/rust-cli/env_logger/issues/337.
