### PR TITLE
Replace humantime with cyborgtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "cyborgtime"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "817fa642fb0ee7fe42e95783e00e0969927b96091bdd4b9b1af082acd943913b"
+
+[[package]]
 name = "env_filter"
 version = "0.1.3"
 dependencies = [
@@ -80,16 +86,10 @@ version = "0.11.6"
 dependencies = [
  "anstream",
  "anstyle",
+ "cyborgtime",
  "env_filter",
- "humantime",
  "log",
 ]
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "log"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,17 +117,18 @@ pre-release-replacements = [
 ]
 
 [features]
-default = ["auto-color", "humantime", "regex"]
+default = ["auto-color", "cyborgtime", "regex"]
 color = ["dep:anstream", "dep:anstyle"]
 auto-color = ["color", "anstream/auto"]
-humantime = ["dep:humantime"]
+cyborgtime = ["dep:cyborgtime"]
+humantime = ["dep:cyborgtime"]
 regex = ["env_filter/regex"]
 unstable-kv = ["log/kv"]
 
 [dependencies]
 log = { version = "0.4.21", features = ["std"] }
 env_filter = { version = "0.1.0", path = "crates/env_filter", default-features = false }
-humantime = { version = "2.0.0", optional = true }
+cyborgtime = { version = "2.0.0", optional = true }
 anstream = { version = "0.6.11", default-features = false, features = ["wincon"], optional = true }
 anstyle = { version = "1.0.6", optional = true }
 

--- a/examples/custom_format.rs
+++ b/examples/custom_format.rs
@@ -17,7 +17,7 @@ $ export MY_LOG_STYLE=never
 If you want to control the logging output completely, see the `custom_logger` example.
 */
 
-#[cfg(all(feature = "color", feature = "humantime"))]
+#[cfg(all(feature = "color", any(feature = "cyborgtime", feature = "humantime")))]
 fn main() {
     use env_logger::{Builder, Env};
 
@@ -49,5 +49,5 @@ fn main() {
     log::info!("a log from `MyLogger`");
 }
 
-#[cfg(not(all(feature = "color", feature = "humantime")))]
+#[cfg(not(all(feature = "color", any(feature = "cyborgtime", feature = "humantime"))))]
 fn main() {}

--- a/src/fmt/humantime.rs
+++ b/src/fmt/humantime.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::time::SystemTime;
 
-use humantime::{
+use cyborgtime::{
     format_rfc3339_micros, format_rfc3339_millis, format_rfc3339_nanos, format_rfc3339_seconds,
 };
 

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -67,7 +67,7 @@ use std::{fmt, io, mem};
 use log::Level;
 use log::Record;
 
-#[cfg(feature = "humantime")]
+#[cfg(any(feature = "cyborgtime", feature = "humantime"))]
 mod humantime;
 #[cfg(feature = "unstable-kv")]
 mod kv;
@@ -76,7 +76,7 @@ pub(crate) mod writer;
 #[cfg(feature = "color")]
 pub use anstyle as style;
 
-#[cfg(feature = "humantime")]
+#[cfg(any(feature = "cyborgtime", feature = "humantime"))]
 pub use self::humantime::Timestamp;
 #[cfg(feature = "unstable-kv")]
 pub use self::kv::*;
@@ -396,7 +396,7 @@ impl DefaultFormat<'_> {
     }
 
     fn write_timestamp(&mut self) -> io::Result<()> {
-        #[cfg(feature = "humantime")]
+        #[cfg(any(feature = "cyborgtime", feature = "humantime"))]
         {
             use self::TimestampPrecision::{Micros, Millis, Nanos, Seconds};
             let ts = match self.timestamp {
@@ -409,7 +409,7 @@ impl DefaultFormat<'_> {
 
             self.write_header_value(ts)
         }
-        #[cfg(not(feature = "humantime"))]
+        #[cfg(not(any(feature = "cyborgtime", feature = "humantime")))]
         {
             // Trick the compiler to think we have used self.timestamp
             // Workaround for "field is never used: `timestamp`" compiler nag.


### PR DESCRIPTION
[`humantime`](https://crates.io/crates/humantime/) seems to be unmaintained and [`cyborgtime`](https://crates.io/crates/cyborgtime/) is fork of it. This change shouldn't affect end users. E.g. "humantime" feature is kept as is.

I also introduced "cyborgtime" feature that currently works same as "humantime".

Ref. https://github.com/rustsec/advisory-db/pull/2249