### PR TITLE
chore(deps): Switch humantime to jiff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,15 +81,33 @@ dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
- "humantime",
+ "jiff",
  "log",
 ]
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
+name = "jiff"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "5c163c633eb184a4ad2a5e7a5dacf12a58c830d717a7963563d4eceb4ced079f"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc3e0019b0f5f43038cf46471b1312136f29e36f54436c6042c8f155fec8789"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "log"
@@ -110,6 +128,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +176,26 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
+name = "serde"
+version = "1.0.218"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.218"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "similar"
@@ -153,6 +224,23 @@ checksum = "16569f53ca23a41bb6f62e0a5084aa1661f4814a67fa33696a79073e03a664af"
 dependencies = [
  "anstream",
 ]
+
+[[package]]
+name = "syn"
+version = "2.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,14 +120,14 @@ pre-release-replacements = [
 default = ["auto-color", "humantime", "regex"]
 color = ["dep:anstream", "dep:anstyle"]
 auto-color = ["color", "anstream/auto"]
-humantime = ["dep:humantime"]
+humantime = ["dep:jiff"]
 regex = ["env_filter/regex"]
 unstable-kv = ["log/kv"]
 
 [dependencies]
 log = { version = "0.4.21", features = ["std"] }
 env_filter = { version = "0.1.0", path = "crates/env_filter", default-features = false }
-humantime = { version = "2.0.0", optional = true }
+jiff = { version = "0.2.3", default-features = false, features = ["std"], optional = true }
 anstream = { version = "0.6.11", default-features = false, features = ["wincon"], optional = true }
 anstyle = { version = "1.0.6", optional = true }
 

--- a/src/fmt/humantime.rs
+++ b/src/fmt/humantime.rs
@@ -109,3 +109,28 @@ impl fmt::Display for Timestamp {
         formatter(self.time).fmt(f)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Timestamp;
+    use crate::TimestampPrecision;
+
+    #[test]
+    fn test_display_timestamp() {
+        let mut ts = Timestamp {
+            time: std::time::SystemTime::UNIX_EPOCH,
+            precision: TimestampPrecision::Nanos,
+        };
+
+        assert_eq!("1970-01-01T00:00:00.000000000Z", format!("{ts}"));
+
+        ts.precision = TimestampPrecision::Micros;
+        assert_eq!("1970-01-01T00:00:00.000000Z", format!("{ts}"));
+
+        ts.precision = TimestampPrecision::Millis;
+        assert_eq!("1970-01-01T00:00:00.000Z", format!("{ts}"));
+
+        ts.precision = TimestampPrecision::Seconds;
+        assert_eq!("1970-01-01T00:00:00Z", format!("{ts}"));
+    }
+}

--- a/src/fmt/humantime.rs
+++ b/src/fmt/humantime.rs
@@ -1,10 +1,6 @@
 use std::fmt;
 use std::time::SystemTime;
 
-use humantime::{
-    format_rfc3339_micros, format_rfc3339_millis, format_rfc3339_nanos, format_rfc3339_seconds,
-};
-
 use crate::fmt::{Formatter, TimestampPrecision};
 
 impl Formatter {
@@ -99,14 +95,16 @@ impl fmt::Debug for Timestamp {
 
 impl fmt::Display for Timestamp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let formatter = match self.precision {
-            TimestampPrecision::Seconds => format_rfc3339_seconds,
-            TimestampPrecision::Millis => format_rfc3339_millis,
-            TimestampPrecision::Micros => format_rfc3339_micros,
-            TimestampPrecision::Nanos => format_rfc3339_nanos,
+        let Ok(ts) = jiff::Timestamp::try_from(self.time) else {
+            return Err(fmt::Error);
         };
 
-        formatter(self.time).fmt(f)
+        match self.precision {
+            TimestampPrecision::Seconds => write!(f, "{ts:.0}"),
+            TimestampPrecision::Millis => write!(f, "{ts:.3}"),
+            TimestampPrecision::Micros => write!(f, "{ts:.6}"),
+            TimestampPrecision::Nanos => write!(f, "{ts:.9}"),
+        }
     }
 }
 


### PR DESCRIPTION
[`humantime`](https://crates.io/crates/humantime/) seems to be unmaintained and [`jiff`](https://crates.io/crates/jiff/) provides the same functionality. This change shouldn't affect end users.

Ref. https://github.com/rustsec/advisory-db/pull/2249