### PR TITLE
feat(fmt): Expose ConfigurableFormat

### DIFF
--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -276,10 +276,9 @@ impl<T: Display> Display for StyledValue<T> {
 #[cfg(not(feature = "color"))]
 type StyledValue<T> = T;
 
-/// The default format.
-///
-/// This format needs to work with any combination of crate features.
-pub(crate) struct ConfigurableFormat {
+/// A [custom format][crate::Builder::format] with settings for which fields to show
+pub struct ConfigurableFormat {
+    // This format needs to work with any combination of crate features.
     pub(crate) timestamp: Option<TimestampPrecision>,
     pub(crate) module_path: bool,
     pub(crate) target: bool,
@@ -294,7 +293,7 @@ pub(crate) struct ConfigurableFormat {
 
 impl ConfigurableFormat {
     /// Format the [`Record`] as configured for outputting
-    pub(crate) fn format(&self, formatter: &mut Formatter, record: &Record<'_>) -> io::Result<()> {
+    pub fn format(&self, formatter: &mut Formatter, record: &Record<'_>) -> io::Result<()> {
         let fmt = ConfigurableFormatWriter {
             format: self,
             buf: formatter,
@@ -307,13 +306,13 @@ impl ConfigurableFormat {
 
 impl ConfigurableFormat {
     /// Whether or not to write the level in the default format.
-    pub(crate) fn level(&mut self, write: bool) -> &mut Self {
+    pub fn level(&mut self, write: bool) -> &mut Self {
         self.level = write;
         self
     }
 
     /// Whether or not to write the source file path in the default format.
-    pub(crate) fn file(&mut self, write: bool) -> &mut Self {
+    pub fn file(&mut self, write: bool) -> &mut Self {
         self.source_file = write;
         self
     }
@@ -321,38 +320,38 @@ impl ConfigurableFormat {
     /// Whether or not to write the source line number path in the default format.
     ///
     /// Only has effect if `format_file` is also enabled
-    pub(crate) fn line_number(&mut self, write: bool) -> &mut Self {
+    pub fn line_number(&mut self, write: bool) -> &mut Self {
         self.source_line_number = write;
         self
     }
 
     /// Whether or not to write the module path in the default format.
-    pub(crate) fn module_path(&mut self, write: bool) -> &mut Self {
+    pub fn module_path(&mut self, write: bool) -> &mut Self {
         self.module_path = write;
         self
     }
 
     /// Whether or not to write the target in the default format.
-    pub(crate) fn target(&mut self, write: bool) -> &mut Self {
+    pub fn target(&mut self, write: bool) -> &mut Self {
         self.target = write;
         self
     }
 
     /// Configures the amount of spaces to use to indent multiline log records.
     /// A value of `None` disables any kind of indentation.
-    pub(crate) fn indent(&mut self, indent: Option<usize>) -> &mut Self {
+    pub fn indent(&mut self, indent: Option<usize>) -> &mut Self {
         self.indent = indent;
         self
     }
 
     /// Configures if timestamp should be included and in what precision.
-    pub(crate) fn timestamp(&mut self, timestamp: Option<TimestampPrecision>) -> &mut Self {
+    pub fn timestamp(&mut self, timestamp: Option<TimestampPrecision>) -> &mut Self {
         self.timestamp = timestamp;
         self
     }
 
     /// Configures the end of line suffix.
-    pub(crate) fn suffix(&mut self, suffix: &'static str) -> &mut Self {
+    pub fn suffix(&mut self, suffix: &'static str) -> &mut Self {
         self.suffix = suffix;
         self
     }
@@ -368,7 +367,7 @@ impl ConfigurableFormat {
     /// The default format uses a space to separate each key-value pair, with an "=" between
     /// the key and value.
     #[cfg(feature = "kv")]
-    pub(crate) fn key_values<F>(&mut self, format: F) -> &mut Self
+    pub fn key_values<F>(&mut self, format: F) -> &mut Self
     where
         F: Fn(&mut Formatter, &dyn log::kv::Source) -> io::Result<()> + Sync + Send + 'static,
     {

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -292,6 +292,78 @@ pub(crate) struct DefaultFormat {
     pub(crate) kv_format: Option<Box<KvFormatFn>>,
 }
 
+impl DefaultFormat {
+    /// Whether or not to write the level in the default format.
+    pub(crate) fn level(&mut self, write: bool) -> &mut Self {
+        self.level = write;
+        self
+    }
+
+    /// Whether or not to write the source file path in the default format.
+    pub(crate) fn file(&mut self, write: bool) -> &mut Self {
+        self.source_file = write;
+        self
+    }
+
+    /// Whether or not to write the source line number path in the default format.
+    ///
+    /// Only has effect if `format_file` is also enabled
+    pub(crate) fn line_number(&mut self, write: bool) -> &mut Self {
+        self.source_line_number = write;
+        self
+    }
+
+    /// Whether or not to write the module path in the default format.
+    pub(crate) fn module_path(&mut self, write: bool) -> &mut Self {
+        self.module_path = write;
+        self
+    }
+
+    /// Whether or not to write the target in the default format.
+    pub(crate) fn target(&mut self, write: bool) -> &mut Self {
+        self.target = write;
+        self
+    }
+
+    /// Configures the amount of spaces to use to indent multiline log records.
+    /// A value of `None` disables any kind of indentation.
+    pub(crate) fn indent(&mut self, indent: Option<usize>) -> &mut Self {
+        self.indent = indent;
+        self
+    }
+
+    /// Configures if timestamp should be included and in what precision.
+    pub(crate) fn timestamp(&mut self, timestamp: Option<TimestampPrecision>) -> &mut Self {
+        self.timestamp = timestamp;
+        self
+    }
+
+    /// Configures the end of line suffix.
+    pub(crate) fn suffix(&mut self, suffix: &'static str) -> &mut Self {
+        self.suffix = suffix;
+        self
+    }
+
+    /// Set the format for structured key/value pairs in the log record
+    ///
+    /// With the default format, this function is called for each record and should format
+    /// the structured key-value pairs as returned by [`log::Record::key_values`].
+    ///
+    /// The format function is expected to output the string directly to the `Formatter` so that
+    /// implementations can use the [`std::fmt`] macros, similar to the main format function.
+    ///
+    /// The default format uses a space to separate each key-value pair, with an "=" between
+    /// the key and value.
+    #[cfg(feature = "kv")]
+    pub(crate) fn key_values<F>(&mut self, format: F) -> &mut Self
+    where
+        F: Fn(&mut Formatter, &dyn log::kv::Source) -> io::Result<()> + Sync + Send + 'static,
+    {
+        self.kv_format = Some(Box::new(format));
+        self
+    }
+}
+
 impl Default for DefaultFormat {
     fn default() -> Self {
         Self {

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -293,6 +293,19 @@ pub(crate) struct ConfigurableFormat {
 }
 
 impl ConfigurableFormat {
+    /// Format the [`Record`] as configured for outputting
+    pub(crate) fn format(&self, formatter: &mut Formatter, record: &Record<'_>) -> io::Result<()> {
+        let fmt = ConfigurableFormatWriter {
+            format: self,
+            buf: formatter,
+            written_header_value: false,
+        };
+
+        fmt.write(record)
+    }
+}
+
+impl ConfigurableFormat {
     /// Whether or not to write the level in the default format.
     pub(crate) fn level(&mut self, write: bool) -> &mut Self {
         self.level = write;
@@ -383,13 +396,7 @@ impl Default for ConfigurableFormat {
 
 impl RecordFormat for ConfigurableFormat {
     fn format(&self, formatter: &mut Formatter, record: &Record<'_>) -> io::Result<()> {
-        let fmt = ConfigurableFormatWriter {
-            format: self,
-            buf: formatter,
-            written_header_value: false,
-        };
-
-        fmt.write(record)
+        self.format(formatter, record)
     }
 }
 

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -238,7 +238,7 @@ impl Builder {
             fmt
         } else {
             Box::new(move |buf, record| {
-                let fmt = DefaultFormat {
+                let fmt = DefaultFormatWriter {
                     timestamp: built.format_timestamp,
                     module_path: built.format_module_path,
                     target: built.format_target,
@@ -310,7 +310,7 @@ type StyledValue<T> = T;
 /// The default format.
 ///
 /// This format needs to work with any combination of crate features.
-struct DefaultFormat<'a> {
+struct DefaultFormatWriter<'a> {
     timestamp: Option<TimestampPrecision>,
     module_path: bool,
     target: bool,
@@ -325,7 +325,7 @@ struct DefaultFormat<'a> {
     kv_format: &'a KvFormatFn,
 }
 
-impl DefaultFormat<'_> {
+impl DefaultFormatWriter<'_> {
     fn write(mut self, record: &Record<'_>) -> io::Result<()> {
         self.write_timestamp()?;
         self.write_level(record)?;
@@ -475,7 +475,7 @@ impl DefaultFormat<'_> {
                 // Create a wrapper around the buffer only if we have to actually indent the message
 
                 struct IndentWrapper<'a, 'b> {
-                    fmt: &'a mut DefaultFormat<'b>,
+                    fmt: &'a mut DefaultFormatWriter<'b>,
                     indent_count: usize,
                 }
 
@@ -531,7 +531,7 @@ mod tests {
 
     use log::{Level, Record};
 
-    fn write_record(record: Record<'_>, fmt: DefaultFormat<'_>) -> String {
+    fn write_record(record: Record<'_>, fmt: DefaultFormatWriter<'_>) -> String {
         let buf = fmt.buf.buf.clone();
 
         fmt.write(&record).expect("failed to write record");
@@ -540,7 +540,7 @@ mod tests {
         String::from_utf8(buf.as_bytes().to_vec()).expect("failed to read record")
     }
 
-    fn write_target(target: &str, fmt: DefaultFormat<'_>) -> String {
+    fn write_target(target: &str, fmt: DefaultFormatWriter<'_>) -> String {
         write_record(
             Record::builder()
                 .args(format_args!("log\nmessage"))
@@ -554,7 +554,7 @@ mod tests {
         )
     }
 
-    fn write(fmt: DefaultFormat<'_>) -> String {
+    fn write(fmt: DefaultFormatWriter<'_>) -> String {
         write_target("", fmt)
     }
 
@@ -570,7 +570,7 @@ mod tests {
     fn format_with_header() {
         let mut f = formatter();
 
-        let written = write(DefaultFormat {
+        let written = write(DefaultFormatWriter {
             timestamp: None,
             module_path: true,
             target: false,
@@ -592,7 +592,7 @@ mod tests {
     fn format_no_header() {
         let mut f = formatter();
 
-        let written = write(DefaultFormat {
+        let written = write(DefaultFormatWriter {
             timestamp: None,
             module_path: false,
             target: false,
@@ -614,7 +614,7 @@ mod tests {
     fn format_indent_spaces() {
         let mut f = formatter();
 
-        let written = write(DefaultFormat {
+        let written = write(DefaultFormatWriter {
             timestamp: None,
             module_path: true,
             target: false,
@@ -636,7 +636,7 @@ mod tests {
     fn format_indent_zero_spaces() {
         let mut f = formatter();
 
-        let written = write(DefaultFormat {
+        let written = write(DefaultFormatWriter {
             timestamp: None,
             module_path: true,
             target: false,
@@ -658,7 +658,7 @@ mod tests {
     fn format_indent_spaces_no_header() {
         let mut f = formatter();
 
-        let written = write(DefaultFormat {
+        let written = write(DefaultFormatWriter {
             timestamp: None,
             module_path: false,
             target: false,
@@ -680,7 +680,7 @@ mod tests {
     fn format_suffix() {
         let mut f = formatter();
 
-        let written = write(DefaultFormat {
+        let written = write(DefaultFormatWriter {
             timestamp: None,
             module_path: false,
             target: false,
@@ -702,7 +702,7 @@ mod tests {
     fn format_suffix_with_indent() {
         let mut f = formatter();
 
-        let written = write(DefaultFormat {
+        let written = write(DefaultFormatWriter {
             timestamp: None,
             module_path: false,
             target: false,
@@ -726,7 +726,7 @@ mod tests {
 
         let written = write_target(
             "target",
-            DefaultFormat {
+            DefaultFormatWriter {
                 timestamp: None,
                 module_path: true,
                 target: true,
@@ -749,7 +749,7 @@ mod tests {
     fn format_empty_target() {
         let mut f = formatter();
 
-        let written = write(DefaultFormat {
+        let written = write(DefaultFormatWriter {
             timestamp: None,
             module_path: true,
             target: true,
@@ -773,7 +773,7 @@ mod tests {
 
         let written = write_target(
             "target",
-            DefaultFormat {
+            DefaultFormatWriter {
                 timestamp: None,
                 module_path: true,
                 target: false,
@@ -796,7 +796,7 @@ mod tests {
     fn format_with_source_file_and_line_number() {
         let mut f = formatter();
 
-        let written = write(DefaultFormat {
+        let written = write(DefaultFormatWriter {
             timestamp: None,
             module_path: false,
             target: false,
@@ -828,7 +828,7 @@ mod tests {
 
         let written = write_record(
             record,
-            DefaultFormat {
+            DefaultFormatWriter {
                 timestamp: None,
                 module_path: false,
                 target: false,
@@ -863,7 +863,7 @@ mod tests {
 
         let written = write_record(
             record,
-            DefaultFormat {
+            DefaultFormatWriter {
                 timestamp: None,
                 module_path: true,
                 target: true,

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -664,8 +664,10 @@ impl Log for Logger {
             }
 
             let print = |formatter: &mut Formatter, record: &Record<'_>| {
-                let _ =
-                    (self.format)(formatter, record).and_then(|_| formatter.print(&self.writer));
+                let _ = self
+                    .format
+                    .format(formatter, record)
+                    .and_then(|_| formatter.print(&self.writer));
 
                 // Always clear the buffer afterwards
                 formatter.clear();

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -258,13 +258,13 @@ impl Builder {
 
     /// Whether or not to write the level in the default format.
     pub fn format_level(&mut self, write: bool) -> &mut Self {
-        self.format.format_level = write;
+        self.format.default_format.level = write;
         self
     }
 
     /// Whether or not to write the source file path in the default format.
     pub fn format_file(&mut self, write: bool) -> &mut Self {
-        self.format.format_file = write;
+        self.format.default_format.source_file = write;
         self
     }
 
@@ -272,7 +272,7 @@ impl Builder {
     ///
     /// Only has effect if `format_file` is also enabled
     pub fn format_line_number(&mut self, write: bool) -> &mut Self {
-        self.format.format_line_number = write;
+        self.format.default_format.source_line_number = write;
         self
     }
 
@@ -287,26 +287,26 @@ impl Builder {
 
     /// Whether or not to write the module path in the default format.
     pub fn format_module_path(&mut self, write: bool) -> &mut Self {
-        self.format.format_module_path = write;
+        self.format.default_format.module_path = write;
         self
     }
 
     /// Whether or not to write the target in the default format.
     pub fn format_target(&mut self, write: bool) -> &mut Self {
-        self.format.format_target = write;
+        self.format.default_format.target = write;
         self
     }
 
     /// Configures the amount of spaces to use to indent multiline log records.
     /// A value of `None` disables any kind of indentation.
     pub fn format_indent(&mut self, indent: Option<usize>) -> &mut Self {
-        self.format.format_indent = indent;
+        self.format.default_format.indent = indent;
         self
     }
 
     /// Configures if timestamp should be included and in what precision.
     pub fn format_timestamp(&mut self, timestamp: Option<fmt::TimestampPrecision>) -> &mut Self {
-        self.format.format_timestamp = timestamp;
+        self.format.default_format.timestamp = timestamp;
         self
     }
 
@@ -332,7 +332,7 @@ impl Builder {
 
     /// Configures the end of line suffix.
     pub fn format_suffix(&mut self, suffix: &'static str) -> &mut Self {
-        self.format.format_suffix = suffix;
+        self.format.default_format.suffix = suffix;
         self
     }
 
@@ -351,7 +351,7 @@ impl Builder {
     where
         F: Fn(&mut Formatter, &dyn log::kv::Source) -> io::Result<()> + Sync + Send + 'static,
     {
-        self.format.kv_format = Some(Box::new(format));
+        self.format.default_format.kv_format = Some(Box::new(format));
         self
     }
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -258,13 +258,13 @@ impl Builder {
 
     /// Whether or not to write the level in the default format.
     pub fn format_level(&mut self, write: bool) -> &mut Self {
-        self.format.default_format.level = write;
+        self.format.default_format.level(write);
         self
     }
 
     /// Whether or not to write the source file path in the default format.
     pub fn format_file(&mut self, write: bool) -> &mut Self {
-        self.format.default_format.source_file = write;
+        self.format.default_format.file(write);
         self
     }
 
@@ -272,7 +272,7 @@ impl Builder {
     ///
     /// Only has effect if `format_file` is also enabled
     pub fn format_line_number(&mut self, write: bool) -> &mut Self {
-        self.format.default_format.source_line_number = write;
+        self.format.default_format.line_number(write);
         self
     }
 
@@ -287,26 +287,26 @@ impl Builder {
 
     /// Whether or not to write the module path in the default format.
     pub fn format_module_path(&mut self, write: bool) -> &mut Self {
-        self.format.default_format.module_path = write;
+        self.format.default_format.module_path(write);
         self
     }
 
     /// Whether or not to write the target in the default format.
     pub fn format_target(&mut self, write: bool) -> &mut Self {
-        self.format.default_format.target = write;
+        self.format.default_format.target(write);
         self
     }
 
     /// Configures the amount of spaces to use to indent multiline log records.
     /// A value of `None` disables any kind of indentation.
     pub fn format_indent(&mut self, indent: Option<usize>) -> &mut Self {
-        self.format.default_format.indent = indent;
+        self.format.default_format.indent(indent);
         self
     }
 
     /// Configures if timestamp should be included and in what precision.
     pub fn format_timestamp(&mut self, timestamp: Option<fmt::TimestampPrecision>) -> &mut Self {
-        self.format.default_format.timestamp = timestamp;
+        self.format.default_format.timestamp(timestamp);
         self
     }
 
@@ -332,7 +332,7 @@ impl Builder {
 
     /// Configures the end of line suffix.
     pub fn format_suffix(&mut self, suffix: &'static str) -> &mut Self {
-        self.format.default_format.suffix = suffix;
+        self.format.default_format.suffix(suffix);
         self
     }
 
@@ -351,7 +351,7 @@ impl Builder {
     where
         F: Fn(&mut Formatter, &dyn log::kv::Source) -> io::Result<()> + Sync + Send + 'static,
     {
-        self.format.default_format.kv_format = Some(Box::new(format));
+        self.format.default_format.key_values(format);
         self
     }
 


### PR DESCRIPTION
The goal is to allow people to compose more complex formatting options (e.g. for #349) by exposing the built-in formatting

A breaking change was split out into #361