### PR TITLE
feat(env_filter): support no_std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,9 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - uses: taiki-e/install-action@cargo-hack
     - name: Default features
-      run: cargo hack check --each-feature --locked --rust-version --ignore-private --workspace --all-targets --keep-going
+      run: |
+        cargo hack check --each-feature --locked --rust-version --ignore-private --package env_logger --all-targets --keep-going
+        cargo hack check --each-feature --locked --version-range 1.81..=1.81 --ignore-private --package env_filter --all-targets --keep-going
   minimal-versions:
     name: Minimal versions
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ unstable-kv = ["kv"]
 
 [dependencies]
 log = { version = "0.4.29", features = ["std"] }
-env_filter = { version = "1.0.0", path = "crates/env_filter", default-features = false }
+env_filter = { version = "1.0.0", path = "crates/env_filter", default-features = false, features = ["std"] }
 jiff = { version = "0.2.22", default-features = false, features = ["std"], optional = true }
 anstream = { version = "1.0.0", default-features = false, features = ["wincon"], optional = true }
 anstyle = { version = "1.0.13", optional = true }

--- a/crates/env_filter/Cargo.toml
+++ b/crates/env_filter/Cargo.toml
@@ -9,7 +9,6 @@ keywords = ["logging", "log", "logger"]
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 include.workspace = true
 
 [package.metadata.docs.rs]
@@ -26,12 +25,13 @@ pre-release-replacements = [
 ]
 
 [features]
-default = ["regex"]
+default = ["std", "regex"]
 regex = ["dep:regex"]
+std = ["regex/std"]
 
 [dependencies]
-log = { version = "0.4.29", features = ["std"] }
-regex = { version = "1.12.3", optional = true, default-features=false, features=["std", "perf"] }
+log = { version = "0.4.29", default-features = false }
+regex = { version = "1.12.3", optional = true, default-features=false, features=["perf"] }
 
 [dev-dependencies]
 snapbox = "1.0"

--- a/crates/env_filter/Cargo.toml
+++ b/crates/env_filter/Cargo.toml
@@ -26,12 +26,13 @@ pre-release-replacements = [
 ]
 
 [features]
-default = ["regex"]
+default = ["std", "regex"]
 regex = ["dep:regex"]
+std = ["log/std", "regex?/std"]
 
 [dependencies]
-log = { version = "0.4.29", features = ["std"] }
-regex = { version = "1.12.3", optional = true, default-features=false, features=["std", "perf"] }
+log = { version = "0.4.29" }
+regex = { version = "1.12.3", optional = true, default-features=false, features=["perf"] }
 
 [dev-dependencies]
 snapbox = "1.0"

--- a/crates/env_filter/src/directive.rs
+++ b/crates/env_filter/src/directive.rs
@@ -1,3 +1,5 @@
+use alloc::string::String;
+
 use log::Level;
 use log::LevelFilter;
 

--- a/crates/env_filter/src/filter.rs
+++ b/crates/env_filter/src/filter.rs
@@ -1,6 +1,5 @@
-use std::env;
-use std::fmt;
-use std::mem;
+use alloc::{borrow::ToOwned, string::ToString, vec::Vec};
+use core::{fmt, mem};
 
 use log::{LevelFilter, Metadata, Record};
 
@@ -48,10 +47,11 @@ impl Builder {
     }
 
     /// Initializes the filter builder from an environment.
+    #[cfg(feature = "std")]
     pub fn from_env(env: &str) -> Builder {
         let mut builder = Builder::new();
 
-        if let Ok(s) = env::var(env) {
+        if let Ok(s) = std::env::var(env) {
             builder.parse(&s);
         }
 
@@ -108,7 +108,10 @@ impl Builder {
         } = parse_spec(filters);
 
         for error in errors {
+            #[cfg(feature = "std")]
             eprintln!("warning: {error}, ignoring it");
+            #[cfg(not(feature = "std"))]
+            log::warn!("{error}, ignoring it");
         }
 
         self.filter = filter;
@@ -258,8 +261,9 @@ impl fmt::Debug for Filter {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{borrow::ToOwned, vec, vec::Vec};
+
     use log::{Level, LevelFilter};
-    use snapbox::{assert_data_eq, str};
 
     use super::{enabled, Builder, Directive, Filter};
 
@@ -486,10 +490,12 @@ mod tests {
 
     #[test]
     fn try_parse_invalid_filter() {
+        #[allow(unused_variables)]
         let error = Builder::new().try_parse("info,crate1=invalid").unwrap_err();
-        assert_data_eq!(
+        #[cfg(feature = "std")]
+        snapbox::assert_data_eq!(
             error,
-            str!["error parsing logger filter: invalid logging spec 'invalid'"]
+            snapbox::str!["error parsing logger filter: invalid logging spec 'invalid'"]
         );
     }
 

--- a/crates/env_filter/src/filter.rs
+++ b/crates/env_filter/src/filter.rs
@@ -1,6 +1,5 @@
-use std::env;
-use std::fmt;
-use std::mem;
+use alloc::{borrow::ToOwned, string::ToString, vec::Vec};
+use core::{fmt, mem};
 
 use log::{LevelFilter, Metadata, Record};
 
@@ -48,10 +47,11 @@ impl Builder {
     }
 
     /// Initializes the filter builder from an environment.
+    #[cfg(feature = "std")]
     pub fn from_env(env: &str) -> Builder {
         let mut builder = Builder::new();
 
-        if let Ok(s) = env::var(env) {
+        if let Ok(s) = std::env::var(env) {
             builder.parse(&s);
         }
 
@@ -108,6 +108,7 @@ impl Builder {
         } = parse_spec(filters);
 
         for error in errors {
+            #[cfg(feature = "std")]
             eprintln!("warning: {error}, ignoring it");
         }
 

--- a/crates/env_filter/src/lib.rs
+++ b/crates/env_filter/src/lib.rs
@@ -38,9 +38,14 @@
 //! ```
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
 #![warn(clippy::print_stderr)]
 #![warn(clippy::print_stdout)]
+#![warn(clippy::std_instead_of_core)]
+#![warn(clippy::std_instead_of_alloc)]
+
+extern crate alloc;
 
 mod directive;
 mod filter;

--- a/crates/env_filter/src/lib.rs
+++ b/crates/env_filter/src/lib.rs
@@ -38,9 +38,14 @@
 //! ```
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 #![warn(missing_docs)]
 #![warn(clippy::print_stderr)]
 #![warn(clippy::print_stdout)]
+#![warn(clippy::std_instead_of_core)]
+#![warn(clippy::std_instead_of_alloc)]
+
+extern crate alloc;
 
 mod directive;
 mod filter;

--- a/crates/env_filter/src/op.rs
+++ b/crates/env_filter/src/op.rs
@@ -24,13 +24,13 @@ impl FilterOp {
 
 #[cfg(not(feature = "regex"))]
 impl FilterOp {
-    pub fn new(spec: &str) -> Result<Self, String> {
+    pub(crate) fn new(spec: &str) -> Result<Self, String> {
         Ok(Self {
             inner: spec.to_string(),
         })
     }
 
-    pub fn is_match(&self, s: &str) -> bool {
+    pub(crate) fn is_match(&self, s: &str) -> bool {
         s.contains(&self.inner)
     }
 }

--- a/crates/env_filter/src/op.rs
+++ b/crates/env_filter/src/op.rs
@@ -1,4 +1,5 @@
-use std::fmt;
+use alloc::string::{String, ToString};
+use core::fmt;
 
 #[derive(Debug, Clone)]
 pub(crate) struct FilterOp {

--- a/crates/env_filter/src/parser.rs
+++ b/crates/env_filter/src/parser.rs
@@ -1,6 +1,7 @@
+use alloc::{borrow::ToOwned, format, string::String, vec::Vec};
+use core::fmt::{Display, Formatter};
+
 use log::LevelFilter;
-use std::error::Error;
-use std::fmt::{Display, Formatter};
 
 use crate::Directive;
 use crate::FilterOp;
@@ -46,12 +47,17 @@ pub struct ParseError {
 }
 
 impl Display for ParseError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "error parsing logger filter: {}", self.details)
     }
 }
 
-impl Error for ParseError {}
+#[cfg(feature = "std")]
+#[allow(clippy::std_instead_of_core)]
+impl std::error::Error for ParseError {}
+
+#[cfg(not(feature = "std"))]
+impl core::error::Error for ParseError {}
 
 /// Parse a logging specification string (e.g: `crate1,crate2::mod3,crate3::x=error/foo`)
 /// and return a vector with log directives.
@@ -115,9 +121,13 @@ pub(crate) fn parse_spec(spec: &str) -> ParseResult {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{borrow::ToOwned, string::ToString};
+
     use crate::ParseError;
     use log::LevelFilter;
-    use snapbox::{assert_data_eq, str, Data, IntoData};
+    #[cfg(feature = "std")]
+    use snapbox::{assert_data_eq, str};
+    use snapbox::{Data, IntoData};
 
     use super::{parse_spec, ParseResult};
 
@@ -164,6 +174,7 @@ mod tests {
         assert!(filter.is_none());
 
         assert_eq!(errors.len(), 1);
+        #[cfg(feature = "std")]
         assert_data_eq!(
             &errors[0],
             str!["invalid logging spec 'crate1::mod1=warn=info'"]
@@ -185,6 +196,7 @@ mod tests {
         assert!(filter.is_none());
 
         assert_eq!(errors.len(), 1);
+        #[cfg(feature = "std")]
         assert_data_eq!(&errors[0], str!["invalid logging spec 'noNumber'"]);
     }
 
@@ -203,6 +215,7 @@ mod tests {
         assert!(filter.is_none());
 
         assert_eq!(errors.len(), 1);
+        #[cfg(feature = "std")]
         assert_data_eq!(&errors[0], str!["invalid logging spec 'wrong'"]);
     }
 
@@ -221,6 +234,7 @@ mod tests {
         assert!(filter.is_none());
 
         assert_eq!(errors.len(), 1);
+        #[cfg(feature = "std")]
         assert_data_eq!(&errors[0], str!["invalid logging spec 'wrong'"]);
     }
 
@@ -394,6 +408,7 @@ mod tests {
         assert!(filter.is_some() && filter.unwrap().to_string() == "a.c");
 
         assert_eq!(errors.len(), 1);
+        #[cfg(feature = "std")]
         assert_data_eq!(
             &errors[0],
             str!["invalid logging spec 'crate1::mod1=error=warn'"]
@@ -425,6 +440,7 @@ mod tests {
         assert!(filter.is_none());
 
         assert_eq!(errors.len(), 1);
+        #[cfg(feature = "std")]
         assert_data_eq!(
             &errors[0],
             str!["invalid logging spec 'debug/abc/a.c' (too many '/'s)"]
@@ -446,14 +462,17 @@ mod tests {
         assert!(filter.is_none());
 
         assert_eq!(errors.len(), 2);
-        assert_data_eq!(
-            &errors[0],
-            str!["invalid logging spec 'crate1::mod1=warn=info'"]
-        );
-        assert_data_eq!(
-            &errors[1],
-            str!["invalid logging spec 'crate3=error=error'"]
-        );
+        #[cfg(feature = "std")]
+        {
+            assert_data_eq!(
+                &errors[0],
+                str!["invalid logging spec 'crate1::mod1=warn=info'"]
+            );
+            assert_data_eq!(
+                &errors[1],
+                str!["invalid logging spec 'crate3=error=error'"]
+            );
+        }
     }
 
     #[test]
@@ -471,8 +490,11 @@ mod tests {
         assert!(filter.is_none());
 
         assert_eq!(errors.len(), 2);
-        assert_data_eq!(&errors[0], str!["invalid logging spec 'noNumber'"]);
-        assert_data_eq!(&errors[1], str!["invalid logging spec 'invalid'"]);
+        #[cfg(feature = "std")]
+        {
+            assert_data_eq!(&errors[0], str!["invalid logging spec 'noNumber'"]);
+            assert_data_eq!(&errors[1], str!["invalid logging spec 'invalid'"]);
+        }
     }
 
     #[test]
@@ -490,18 +512,23 @@ mod tests {
         assert!(filter.is_none());
 
         assert_eq!(errors.len(), 2);
-        assert_data_eq!(
-            &errors[0],
-            str!["invalid logging spec 'crate1::mod1=debug=info'"]
-        );
-        assert_data_eq!(&errors[1], str!["invalid logging spec 'invalid'"]);
+        #[cfg(feature = "std")]
+        {
+            assert_data_eq!(
+                &errors[0],
+                str!["invalid logging spec 'crate1::mod1=debug=info'"]
+            );
+            assert_data_eq!(&errors[1], str!["invalid logging spec 'invalid'"]);
+        }
     }
 
     #[test]
     fn parse_error_message_single_error() {
+        #[allow(unused_variables)]
         let error = parse_spec("crate1::mod1=debug=info,crate2=debug")
             .ok()
             .unwrap_err();
+        #[cfg(feature = "std")]
         assert_data_eq!(
             error,
             str!["error parsing logger filter: invalid logging spec 'crate1::mod1=debug=info'"]
@@ -510,9 +537,11 @@ mod tests {
 
     #[test]
     fn parse_error_message_multiple_errors() {
+        #[allow(unused_variables)]
         let error = parse_spec("crate1::mod1=debug=info,crate2=debug,crate3=invalid")
             .ok()
             .unwrap_err();
+        #[cfg(feature = "std")]
         assert_data_eq!(
             error,
             str!["error parsing logger filter: invalid logging spec 'crate1::mod1=debug=info'"]

--- a/crates/env_filter/src/parser.rs
+++ b/crates/env_filter/src/parser.rs
@@ -1,6 +1,7 @@
+use alloc::{borrow::ToOwned, format, string::String, vec::Vec};
+use core::fmt::{Display, Formatter};
+
 use log::LevelFilter;
-use std::error::Error;
-use std::fmt::{Display, Formatter};
 
 use crate::Directive;
 use crate::FilterOp;
@@ -46,12 +47,13 @@ pub struct ParseError {
 }
 
 impl Display for ParseError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "error parsing logger filter: {}", self.details)
     }
 }
 
-impl Error for ParseError {}
+#[cfg(feature = "std")]
+impl std::error::Error for ParseError {}
 
 /// Parse a logging specification string (e.g: `crate1,crate2::mod3,crate3::x=error/foo`)
 /// and return a vector with log directives.


### PR DESCRIPTION
Based on #378, this PR adds a new default feature `std` that allows the crate to be used in no_std crates. I tried to incorporate the feedback that was given to the previous PR. Hopefully, I didn't miss anything.

The PR is still a breaking change for crates that have the default features disabled and use `Builder::from_env`, or expect `Builder::parse` to print warnings to stderr and don't have the log target set to stderr.

It may make sense to squash 9c70eafd442e7ec33a6e04cdebd3f50a77af444b and 663c9c22452bb588c4c8e6ee187e659f10132092 (and potentially b754c66235c7ef0e8af03954b2816e93f9fdb709). I kept them separate to make sure I don't misattribute the work of the author of the base PR.